### PR TITLE
251 hotfix tutorial (#254)

### DIFF
--- a/inc/js/factory-class-extenders/class-extenders.mjs
+++ b/inc/js/factory-class-extenders/class-extenders.mjs
@@ -125,7 +125,6 @@ function extendClass_contribution(originClass, referencesObject) {
  */
 function extendClass_conversation(originClass, referencesObject) {
     class Conversation extends originClass {
-        #botId
         #factory
         #messages = []
         #saved = false
@@ -135,13 +134,13 @@ function extendClass_conversation(originClass, referencesObject) {
          * @param {Object} obj - The object to construct the conversation from.
          * @param {AgentFactory} factory - The factory instance.
          * @param {Object} thread - The thread instance.
-         * @param {Guid} botId - The initial active bot id (can mutate)
+         * @param {Guid} bot_id - The initial active bot id (can mutate)
          */
-        constructor(obj, factory, thread, botId) {
+        constructor(obj, factory, thread, bot_id){
             super(obj)
             this.#factory = factory
             this.#thread = thread
-            this.#botId = botId
+            this.bot_id = bot_id
             this.form = this.form
                 ?? 'system'
             this.name = `conversation_${this.#factory.mbr_id}_${thread.thread_id}`
@@ -212,16 +211,16 @@ function extendClass_conversation(originClass, referencesObject) {
          * @returns {Guid} - The bot id.
          */
         get botId(){
-            return this.#botId
+            return this.bot_id
         }
         /**
          * Set the id {Guid} of the conversation's bot.
          * @setter
-         * @param {Guid} botId - The bot id.
+         * @param {Guid} bot_id - The bot id.
          * @returns {void}
          */
-        set botId(botId){
-            this.#botId = botId
+        set botId(bot_id){
+            this.bot_id = bot_id
         }
         get isSaved(){
             return this.#saved

--- a/inc/js/mylife-avatar.mjs
+++ b/inc/js/mylife-avatar.mjs
@@ -63,7 +63,7 @@ class Avatar extends EventEmitter {
         /* experience variables */
         this.#experienceGenericVariables = mAssignGenericExperienceVariables(this.#experienceGenericVariables, this)
         /* llm services */
-        this.#llmServices.botId = mBot_idOverride && this.isMyLife
+        this.#llmServices.bot_id = mBot_idOverride && this.isMyLife
             ? mBot_idOverride
             : this.activeBot.bot_id
         return this
@@ -540,14 +540,14 @@ class Avatar extends EventEmitter {
             throw new Error('MyLife avatar cannot summarize files.')
         if(!fileId?.length && !fileName?.length)
             throw new Error('File id or name required for summarization.')
-        const { bot_id: botId, thread_id, } = this.personalAssistant
+        const { bot_id, thread_id, } = this.personalAssistant
         const prompt = `Summarize this file document: name=${ fileName }, id=${ fileId }`
         const response = {
             messages: [],
             success: false,
         }
         try{
-            let messages = await mCallLLM(this.#llmServices, { botId, thread_id, }, prompt, this.#factory, this)
+            let messages = await mCallLLM(this.#llmServices, { bot_id, thread_id, }, prompt, this.#factory, this)
             messages = messages
                 .map(message=>mPruneMessage(this.personalAssistant, message, 'mylife-file-summary', processStartTime))
                 .filter(message=>message && message.role!=='user')
@@ -755,9 +755,6 @@ class Avatar extends EventEmitter {
     */
     get being(){  
         return 'human'
-    }
-    get biographer(){
-        return this.#bots.find(_bot=>_bot.type==='personal-biographer')
     }
     get biographer(){
         return this.#bots.find(_bot=>_bot.type==='personal-biographer')
@@ -1415,8 +1412,8 @@ async function mEventDialog(llm, experience, event, iteration=0){
                 console.log('mEventDialog::bot id not found in cast', characterId, castMember, bot)
                 throw new Error('Bot id not found in cast.')
             }
-            scriptDialog.botId = bot_id ?? scriptAdvisorBotId
-            console.log('mEventDialog::bot id found in cast', characterId, castMember.inspect(true), scriptDialog.botId)
+            scriptDialog.bot_id = bot_id ?? scriptAdvisorBotId
+            console.log('mEventDialog::bot id found in cast', characterId, castMember.inspect(true), scriptDialog.bot_id)
             if(example?.length)
                 prompt = `using example: "${example}";\n` + prompt
             if(dialogVariables.length)
@@ -1505,7 +1502,7 @@ async function mEventInput(llm, experience, event, iteration=0, memberInput){
         ?? experience.cast.find(castMember=>castMember.id===characterId)?.bot?.bot_id
         ?? experience.cast[0]?.bot?.bot_id
     const scriptConsultant = scriptAdvisor ?? scriptDialog ?? dialog
-    scriptConsultant.botId = scriptAdvisorBotId
+    scriptConsultant.bot_id = scriptAdvisorBotId
     const messages = await mCallLLM(llm, scriptConsultant, prompt)
         ?? []
     if(!messages.length){


### PR DESCRIPTION
* 231 version 0010 updates (#239) (#240)

* 20240604 @Mookse
- teams() route
- teams(teamId) returns a fully formed team from server with new bots (when instructions provided)

* 20240604 @Mookse
- fix bot-bar `setActiveBot`
- cosmetic

* 20240604 @Mookse
- fix duplicate team members return

* 20240604 @Mookse
- botBar reordered

* 20240605 @Mookse
- teams  must be active

* 20240605 @Mookse
- default mods

* 20240605 @Mookse
- create (non-custom) bot frontend
- diary updates

* 20240605 @Mookse
- imagining `share memory`

* 20240606 @Mookse
- story updates

* 20240606 @Mookse
- minor cosmetics

* 20240606 @Mookse
- fetchShadows()
- ignite shadow: member-version (wip)

* 20240607 @Mookse
- `shadow` initial endpoint

* 20240607 @Mookse
- add processingBotId to payload (so that frontend can determine if it should setActive)

* 20240607 @Mookse
- front-end receives message about updating from agent shadow

* 20240607 @Mookse
- shadow cosmetics

* 20240607 @Mookse
- biographer openai function definitions

* 20240607 @Mookse
- now _that's_ an error

* 20240607 @Mookse
- updateSummary() **note**: wip as thread got stopped

* 20240608 @Mookse
- updates summary

* 20240608 @Mookse
- remove dataset after shadow triggered
- add `proxy` endpoint to shadow ideas

* 20240608 @Mookse
- `globals.getGPTJavascriptFunction`: `getSummary`, `updateSummary`
- `updateBotInstructions` route
- on setActiveBot checks versions and updates as needed

* 20240609 @Mookse
- cosmetic

* 20240609 @Mookse stable wip
kicking off memory is correct, need tuning of instructions or alternate scene-stepwise motion, no problem small error left in frontend for more testing but time to save

* 20240618 @Mookse
- cosmetic: file under "the right evocation can make all the difference"

* 20240618 @Mookse
- cosmetic in dribs and drabs

* 20240618 @Mookse
- frontend 'next' fix

* version 0011 updates (#244)

* 231 version 0010 updates (#239)

* 20240604 @Mookse
- teams() route
- teams(teamId) returns a fully formed team from server with new bots (when instructions provided)

* 20240604 @Mookse
- fix bot-bar `setActiveBot`
- cosmetic

* 20240604 @Mookse
- fix duplicate team members return

* 20240604 @Mookse
- botBar reordered

* 20240605 @Mookse
- teams  must be active

* 20240605 @Mookse
- default mods

* 20240605 @Mookse
- create (non-custom) bot frontend
- diary updates

* 20240605 @Mookse
- imagining `share memory`

* 20240606 @Mookse
- story updates

* 20240606 @Mookse
- minor cosmetics

* 20240606 @Mookse
- fetchShadows()
- ignite shadow: member-version (wip)

* 20240607 @Mookse
- `shadow` initial endpoint

* 20240607 @Mookse
- add processingBotId to payload (so that frontend can determine if it should setActive)

* 20240607 @Mookse
- front-end receives message about updating from agent shadow

* 20240607 @Mookse
- shadow cosmetics

* 20240607 @Mookse
- biographer openai function definitions

* 20240607 @Mookse
- now _that's_ an error

* 20240607 @Mookse
- updateSummary() **note**: wip as thread got stopped

* 20240608 @Mookse
- updates summary

* 20240608 @Mookse
- remove dataset after shadow triggered
- add `proxy` endpoint to shadow ideas

* 20240608 @Mookse
- `globals.getGPTJavascriptFunction`: `getSummary`, `updateSummary`
- `updateBotInstructions` route
- on setActiveBot checks versions and updates as needed

* 20240609 @Mookse
- cosmetic

* 20240609 @Mookse stable wip
kicking off memory is correct, need tuning of instructions or alternate scene-stepwise motion, no problem small error left in frontend for more testing but time to save

* 20240618 @Mookse
- cosmetic: file under "the right evocation can make all the difference"

* 20240618 @Mookse
- cosmetic in dribs and drabs

* 20240618 @Mookse
- frontend 'next' fix

* 20240621 @Mookse
- redirect logged in members to `/members`

* 20240626 @Mookse
- registration -> createAccount with Q

* 20240626 @Mookse
- hostedMembers fix

* 20240626 @Mookse
- avatar document name fix

* 20240626 @Mookse
- instruction change

* 20240626 @Mookse
- page-loader

* 20240626 @Mookse
- special pages fix

---------



* Version 0.0.11 (#243)

* 231 version 0010 updates (#239)

* 20240604 @Mookse
- teams() route
- teams(teamId) returns a fully formed team from server with new bots (when instructions provided)

* 20240604 @Mookse
- fix bot-bar `setActiveBot`
- cosmetic

* 20240604 @Mookse
- fix duplicate team members return

* 20240604 @Mookse
- botBar reordered

* 20240605 @Mookse
- teams  must be active

* 20240605 @Mookse
- default mods

* 20240605 @Mookse
- create (non-custom) bot frontend
- diary updates

* 20240605 @Mookse
- imagining `share memory`

* 20240606 @Mookse
- story updates

* 20240606 @Mookse
- minor cosmetics

* 20240606 @Mookse
- fetchShadows()
- ignite shadow: member-version (wip)

* 20240607 @Mookse
- `shadow` initial endpoint

* 20240607 @Mookse
- add processingBotId to payload (so that frontend can determine if it should setActive)

* 20240607 @Mookse
- front-end receives message about updating from agent shadow

* 20240607 @Mookse
- shadow cosmetics

* 20240607 @Mookse
- biographer openai function definitions

* 20240607 @Mookse
- now _that's_ an error

* 20240607 @Mookse
- updateSummary() **note**: wip as thread got stopped

* 20240608 @Mookse
- updates summary

* 20240608 @Mookse
- remove dataset after shadow triggered
- add `proxy` endpoint to shadow ideas

* 20240608 @Mookse
- `globals.getGPTJavascriptFunction`: `getSummary`, `updateSummary`
- `updateBotInstructions` route
- on setActiveBot checks versions and updates as needed

* 20240609 @Mookse
- cosmetic

* 20240609 @Mookse stable wip
kicking off memory is correct, need tuning of instructions or alternate scene-stepwise motion, no problem small error left in frontend for more testing but time to save

* 20240618 @Mookse
- cosmetic: file under "the right evocation can make all the difference"

* 20240618 @Mookse
- cosmetic in dribs and drabs

* 20240618 @Mookse
- frontend 'next' fix

* 238 version 0011 updates (#242)

* 231 version 0010 updates (#239) (#240)

* 20240604 @Mookse
- teams() route
- teams(teamId) returns a fully formed team from server with new bots (when instructions provided)

* 20240604 @Mookse
- fix bot-bar `setActiveBot`
- cosmetic

* 20240604 @Mookse
- fix duplicate team members return

* 20240604 @Mookse
- botBar reordered

* 20240605 @Mookse
- teams  must be active

* 20240605 @Mookse
- default mods

* 20240605 @Mookse
- create (non-custom) bot frontend
- diary updates

* 20240605 @Mookse
- imagining `share memory`

* 20240606 @Mookse
- story updates

* 20240606 @Mookse
- minor cosmetics

* 20240606 @Mookse
- fetchShadows()
- ignite shadow: member-version (wip)

* 20240607 @Mookse
- `shadow` initial endpoint

* 20240607 @Mookse
- add processingBotId to payload (so that frontend can determine if it should setActive)

* 20240607 @Mookse
- front-end receives message about updating from agent shadow

* 20240607 @Mookse
- shadow cosmetics

* 20240607 @Mookse
- biographer openai function definitions

* 20240607 @Mookse
- now _that's_ an error

* 20240607 @Mookse
- updateSummary() **note**: wip as thread got stopped

* 20240608 @Mookse
- updates summary

* 20240608 @Mookse
- remove dataset after shadow triggered
- add `proxy` endpoint to shadow ideas

* 20240608 @Mookse
- `globals.getGPTJavascriptFunction`: `getSummary`, `updateSummary`
- `updateBotInstructions` route
- on setActiveBot checks versions and updates as needed

* 20240609 @Mookse
- cosmetic

* 20240609 @Mookse stable wip
kicking off memory is correct, need tuning of instructions or alternate scene-stepwise motion, no problem small error left in frontend for more testing but time to save

* 20240618 @Mookse
- cosmetic: file under "the right evocation can make all the difference"

* 20240618 @Mookse
- cosmetic in dribs and drabs

* 20240618 @Mookse
- frontend 'next' fix

* 20240621 @Mookse
- redirect logged in members to `/members`

* 20240626 @Mookse
- registration -> createAccount with Q

* 20240626 @Mookse
- hostedMembers fix

* 20240626 @Mookse
- avatar document name fix

* 20240626 @Mookse
- instruction change

* 20240626 @Mookse
- page-loader

* 20240626 @Mookse
- special pages fix

---------



---------



* 20240705 @Mookse
- hotfix for experiences

---------