### PR TITLE
509 version 0037 (#520)

### DIFF
--- a/inc/js/agents/system/bot-agent.mjs
+++ b/inc/js/agents/system/bot-agent.mjs
@@ -205,6 +205,10 @@ class Bot {
 		if(!type?.length){
 			type = this.type
 			switch(type){
+				case 'avatar':
+				case 'personal-avatar':
+					type='chat'
+					break
 				case 'diary':
 				case 'journal':
 				case 'journaler':
@@ -212,7 +216,7 @@ class Bot {
 					break
 				case 'biographer':
 				case 'personal-biographer':
-					type = 'memory'
+					type='memory'
 					break
 				default:
 					break
@@ -423,7 +427,6 @@ class Bot {
 				this.tools.forEach(tool=>{
 					if(tool.type!=='function')
 						return
-					console.log('mcpBot::tool', tool)
 					const { description, parameters, } = tool.function
 					let { name, } = tool.function
 					const inputSchema = {
@@ -445,7 +448,7 @@ class Bot {
 				})
 			this.#mcp = mcp
 			if(!this.isMyLife)
-				this.update({ mcp, }) // @todo - save mcp to document when not .isMyLife (no await)
+				this.update({ mcp, }) // save mcp to document (no await)
 		}
 		return this.#mcp
 	}
@@ -663,7 +666,7 @@ class BotAgent {
 	 * @param {object} mcpData - The MCP data to pass to the function
 	 * @returns {object} - The MCP-ready result of the function call
 	 */
-	async mcp_bot_function(functionName, mcpData){
+	async mcpFunction(functionName, mcpData){
 		functionName = functionName.replace('mylife_', 'mcp_')
 		if(typeof this[functionName]==='function')
 			return await this[functionName](mcpData)
@@ -676,15 +679,25 @@ class BotAgent {
 	}
 	async mcp_change_title(mcpdata){
 		const { itemId, title, } = mcpdata
+		let error,
+			result
 		if(!itemId?.length)
-			throw new Error('Item id required')
+			error = {
+				code: -32602,
+				data: mcpdata,
+				message: '`itemId` parameter required'
+			}
 		if(!title?.length)
-			throw new Error('Title required')
-		const { id, } = await this.#factory.updateItem({ id: itemId, title })
-		const result = !id?.length || id!==itemId
+			error = {
+				code: -32602,
+				data: mcpdata,
+				message: '`title` parameter required'
+			}
+		const { id, title: newTitle, } = await this.#factory.updateItem({ id: itemId, title })
+		result = id?.length && id===itemId
 			? {
 				content: [{
-					text: `Item title updated successfully: ${ itemId }`,
+					text: `Item title updated successfully: ${ itemId } to ${ newTitle }`,
 					type: 'text',
 				}],
 				isError: false,
@@ -696,27 +709,32 @@ class BotAgent {
 				}],
 				isError: true,
 			}
-		return result
+		return { error, result, }
 	}
 	async mcp_chat(mcpdata){
 		const { message, } = mcpdata
 		const Conversation = await this.activeBot.chat(message, message, true, this.avatar)
 		const content = Conversation.getMessages()
 			.map(message=>({ text: message.content, type: 'text', }))
-			// @todo - looks as though Avatar and biographer both used thread_7cM3ujWethnmRSunWCJYHgw3 - was this fluke of error or is it a current bug?
 		const result = {
 			content,
 			isError: false,
 		}
-		return result
+		return { result, }
 	}
 	async mcp_get_summary(mcpdata){
 		const { itemId, } = mcpdata
+		let error,
+			result
 		if(!itemId?.length)
-			throw new Error('Item id required')
+			error = {
+				code: -32602,
+				data: mcpdata,
+				message: '`itemId` parameter required'
+			}
 		const { summary, } = await this.#factory.item(itemId)
 			?? {}
-		const result = summary?.length
+		result = summary?.length
 			? {
 				content: [{
 					text: summary,
@@ -731,19 +749,34 @@ class BotAgent {
 				}],
 				isError: true,
 			}
-		return result
+		return { error, result, }
 	}
 	async mcp_get_memories(mcpdata){
-		// route to biographer
-		// no need to activate bot
+		const preface = 'Here are the titles and ids (display only titles for human member) for the memories we have created together:\n'
+		const response = ( await this.bot(undefined, 'biographer').collections() )
+			.map(item=>({
+				id: item.id,
+				title: item.title,
+			}))
+		const success = response?.length > 0
+		return { preface, response, success, }
 	}
 	async mcp_switch_bot(mcpdata){
 		const { team='memory', type, } = mcpdata
-		let result
+		let error,
+			result
         if(this.isMyLife)
-            throw new Error('MyLife avatar cannot switch bot.')
+			error = {
+				code: 403,
+				data: mcpdata,
+				message: 'MyLife System Avatar cannot switch bots'
+			}
         if(team!=='memory')
-            throw new Error('Only memory team available.')
+			error = {
+				code: -32602,
+				data: mcpdata,
+				message: 'Currently only the Memory Team is supported'
+			}
 		const Bot = this.bot(undefined, type)
 		if(this.activeBot.id===Bot.id)
 			result = {
@@ -764,7 +797,11 @@ class BotAgent {
 				notification: 'notifications/tools/list_changed'
 			}
 		}
-		return result
+		return {
+			error,
+			result,
+			toolListChanged: true, // true for switching bots, as they have different skills
+		}
 	}
     /**
      * Migrates a bot to a new, presumed combined (with internal or external) bot.

--- a/inc/js/controllers/mcp-functions.mjs
+++ b/inc/js/controllers/mcp-functions.mjs
@@ -3,532 +3,72 @@ import chalk from 'chalk'
 import fs from 'fs'
 import path from 'path'
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js'
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
 import { challenge, } from './functions.mjs'
 /* modular constants */
 const mJsonRpcVersion = process.env.MCP_JSONRPC_Version,
-    mJsonRpcProtocolVersion = process.env.MCP_JSONRPC_Protocol_Version
+    mJsonRpcProtocolVersion = process.env.MCP_JSONRPC_Protocol_Version,
+    mPageSize = process.env.MCP_PAGE_SIZE
+        ?? 100
 /* public functions */
-async function mcpCallBot(ctx){
-    let { error, result, } = mcpInitializationChecks(ctx, 'bot')
-    const { avatar: Avatar, mcp, sessionMeta, } = ctx.state
-    const { runs, transportEntry, } = sessionMeta
-    const { args, jsonrpc, method, name, params, progressToken, protocolVersion, run_id, _meta, } = mcp
-    if(!(error ?? result)){
-        const methodBase = method.split('/')[0]
-        const methodAction = method.split('/').pop()
-        switch(methodBase){
-            case 'initialize': /* intentionally empty as it is required to cascade through for authentication */
-                break
-            case 'tools':
-                switch(methodAction){
-                    case 'call':
-                        if(!params)
-                            error = {
-                                code: 500,
-                                data: { arguments: args, id, method, name, params, sessionId, },
-                                message: '`params` field required for tool call',
-                            }
-                        else
-                            if(name==='mylife_login')
-                                result = await mcpLogin(ctx, transportEntry, args, jsonrpc)
-                            else {
-                                if(ctx.state.locked)
-                                    error = {
-                                        code: 500,
-                                        data: { arguments: args, id, method, name, params, sessionId, },
-                                        message: 'session is locked',
-                                    }
-                                else
-                                    try {
-                                        result = await Avatar.mcp_bot_function(name, args)
-                                        if(result.notification?.length){
-                                            mcpSendNotification(transportEntry, jsonrpc, result.notification)
-                                            delete result.notification
-                                        }
-                                    } catch (toolError) {
-                                        result = {
-                                            content: [{
-                                                text: `Error executing tool "${ name }": ${ toolError.message || 'Unknown error' }`,
-                                                type: 'text',
-                                            }],
-                                            isError: true,
-                                        }
-                                    }
-                        }
-                        break
-                    case 'list':
-                        result = {
-                            tools: Avatar.isMyLife
-                                ? Avatar.mcpProxy.tools
-                                : Avatar.mcp.tools,
-                        }
-                        break
-                    default:
-                        error = {
-                            code: 500,
-                            data: {
-                                arguments: args,
-                                id,
-                                method,
-                                sessionId,
-                            },
-                            message: `MCP Call request\nmethodAction = ${ methodAction }\nUnknown or unhandled method\nPlease try again in all lowercase and without spaces`,
-                        }
-                        break
-                }
-                break
-            case 'notifications':
-                const notificationType = method.split('/').pop()
-                switch(notificationType){
-                    case 'cancelled':
-                        const { reason, requestId, } = params
-                        if(ctx.Globals.isValidGuid(requestId))
-                            id = requestId
-                        console.log(chalk.yellow('MCP Call request - cancelled'), reason, requestId)
-                        break
-                    case 'initialized':
-                        /* intentionally empty as it is required to cascade through for authentication */
-                        break
-                    default:
-                        break
-                }
-                break
-            case 'ping':
-                result = {}
-                break
-            case 'prompts':
-            case 'resources':
-            default:
-                console.log(chalk.red('MCP BOT Call request - unhandled method'), method)
-                error = {
-                    code: 500,
-                    data: {
-                        arguments: args,
-                        id,
-                        method,
-                        sessionId,
-                    },
-                    message: 'MCP BOT Call request: unknown or unhandled method; please try again in all lowercase and without spaces',
-                }
-                break
+/**
+ * Primary handler for an MCP request.
+ * @param {Koa} ctx - Koa context object
+ */
+async function mcpCall(ctx){
+    const { Globals, session, state: {
+            avatar: Avatar, mcp, requestType, sessionMeta,
+        } = {}
+    } = ctx
+    const { initializeConfirmation, transportEntry, } = sessionMeta
+        ?? {}
+    /* 2025-03-26 mcp batch request */
+    const mcpRequests = Array.isArray(mcp)
+        ? mcp
+        : [mcp]
+    for(const mcpRequest of mcpRequests){
+        try {
+            await mMcpCall(ctx, mcpRequest, Avatar, sessionMeta, requestType)
+        } catch (err) {
+            console.log(chalk.red('mcpCall()::error'), err)
+            const { id, jsonrpc } = mcpRequest
+            const error = {
+                code: 500,
+                message: err.message ?? 'Unhandled MCP Error',
+                data: err.stack ?? err,
+            }
+            if(!!transportEntry)
+                await mcpSendResponse(ctx, transportEntry, jsonrpc, error, id, undefined)
         }
     }
-    sessionMeta.runs = runs.filter((run)=>(run.id!==run_id))
-    mcpSendResponse(transportEntry, jsonrpc, error, run_id, result)
-    ctx.status = 200
-}
-/* System Avatar MCP Functions */
-async function mcpCallSystem(ctx){
-    let { error, result, } = mcpInitializationChecks(ctx)
-    const { avatar: Avatar, mcp, sessionMeta, } = ctx.state
-    const { runs, transportEntry, } = sessionMeta
-    const { args, jsonrpc, method, name, progressToken, protocolVersion, params, run_id, _meta, } = mcp
-    if(!(error ?? result)){
-        const methodBase = method.split('/')[0]
-        const methodAction = method.split('/').pop()
-        switch(methodBase){
-            case 'prompts':
-                switch(methodAction){
-                    case 'get':
-                        switch(name){
-                            case 'mylife_company_information':
-                                const { infoType, } = args
-                                result = {
-                                    description: 'Prompt to ask Q about MyLife',
-                                    messages: [
-                                        {
-                                            role: 'user',
-                                            content: {
-                                                type: 'text',
-                                                text: `Ask Q about MyLife regarding: ${ infoType }`,
-                                            }
-                                        }
-                                    ]
-                                }
-                                break
-                            default:
-                                break
-                        }
-                        break
-                    case 'list':
-                        result = {
-                            prompts: Avatar.mcp.prompts,
-                        }
-                        break
-                }
-                break
-            case 'resources':
-                switch(methodAction){
-                    case 'list':
-                        result = {
-                            resources: Avatar.mcp.resources,
-                        }
-                        break
-                    case 'read':
-                        const { uri, } = params
-                        switch(uri){
-                            case 'file://MyLife_Summary.pdf':
-                                const summaryPath = path.join(ctx.Globals.rootDirectory, "views", "assets", "pdf", "MyLife_Summary.pdf")
-                                const pdfSummary = mReadPdf(summaryPath)
-                                result = {
-                                    contents: [{
-                                        blob: pdfSummary,
-                                        mimeType: 'application/pdf',
-                                        uri,
-                                    }]
-                                }
-                                break
-                            case 'file://MyLife_Board.pdf':
-                                const boardPath = path.join(ctx.Globals.rootDirectory, "views", "assets", "pdf", "MyLife_Board.pdf")
-                                const pdfBoard = mReadPdf(boardPath)
-                                result = {
-                                    contents: [{
-                                        blob: pdfBoard,
-                                        mimeType: 'application/pdf',
-                                        uri,
-                                    }]
-                                }
-                                break
-                            default:
-                                let text = ''
-                                try {
-                                    const response = await fetch(uri)
-                                    text = ( await response.text() ).trim()
-                                } catch (error) {
-                                    console.error(chalk.red('Error fetching resource:'), uri, error)
-                                    text = `Error fetching external resource: ${error.message}`
-                                }
-                                result = {
-                                    contents: [{
-                                        mimeType: 'text/html',
-                                        text,
-                                        uri,
-                                    }]
-                                }
-                                break
-                        }
-                        break
-                    default:
-                        break
-                }
-                break
-            case 'tools':
-                switch(methodAction){
-                    case 'call':
-                        if(!params)
-                            error = {
-                                code: 500,
-                                data: {
-                                    arguments: args,
-                                    id,
-                                    method,
-                                    name,
-                                    params,
-                                    sessionId,
-                                },
-                                message: 'params are required for tool call',
-                            }
-                        else
-                            switch(name){
-                                case 'get_shared_memories':
-                                    const { cursor, } = args
-                                        ?? {}
-                                    const pageSize = 10
-                                    let decodedCursor = 0
-                                    try {
-                                        if(cursor){
-                                            const parsed = JSON.parse(Buffer.from(cursor, 'base64').toString())
-                                            decodedCursor = parsed.index
-                                                ?? 0
-                                        }
-                                    } catch (err) {
-                                        throw {
-                                            code: -32602,
-                                            message: 'Invalid cursor format',
-                                        }
-                                    }
-                                    const memories = await Avatar.sharedMemories()
-                                    const total = memories.length
-                                    const memoryPage = memories.slice(decodedCursor, decodedCursor+pageSize)
-                                    const memoryPageHasNext = decodedCursor + pageSize < total
-                                    const nextCursor = memoryPageHasNext
-                                        ? Buffer.from(JSON.stringify({ index: decodedCursor + pageSize })).toString('base64')
-                                        : null
-                                    result = {
-                                        content: [{
-                                            text: `Here is the array of shared memories, only share the titles with the human, and use ID to connect to tools and services.\n${ JSON.stringify(memories, null, 2) }`,
-                                            type: 'text',
-                                        }],
-                                        isError: false,
-                                        metadata: {
-                                            memories,
-                                            total: memories.length,
-                                        },
-                                        nextCursor,
-                                    }
-                                    break
-                                case 'get_shared_memory':
-                                    let { input: sharedMemoryInput, memoryId: sharedMemoryMemoryId, } = args
-                                    let Share = sessionMeta.Share
-                                    if(!Share || Share.instanceId!==sharedMemoryMemoryId){
-                                        let sharedMemoryInterval01
-                                        if(progressToken){
-                                            let progress = 0
-                                            sharedMemoryInterval01 = setInterval(_=>{
-                                                progress += 10
-                                                transportEntry.send({
-                                                    jsonrpc,
-                                                    method: 'notifications/progress',
-                                                    params:{
-                                                        message: `Retrieving shared memory header`,
-                                                        progress,
-                                                        progressToken,
-                                                    },
-                                                })
-                                            }, 2500)
-                                        }
-                                        const { instanceId, } = await Avatar.validateShare(sharedMemoryMemoryId)
-                                        if(!instanceId){
-                                            result = {
-                                                content: [{
-                                                    text: `The memoryId ${ sharedMemoryMemoryId } is not valid`,
-                                                    type: 'text',
-                                                }],
-                                                isError: true,
-                                            }
-                                            break
-                                        }
-                                        sharedMemoryMemoryId = instanceId
-                                        await Avatar.shareHeader(sharedMemoryMemoryId)
-                                        Share = await Avatar.share(sharedMemoryMemoryId)
-                                        if(sharedMemoryInterval01)
-                                            clearInterval(sharedMemoryInterval01)
-                                        sessionMeta.Share = Share
-                                        Share = sessionMeta.Share
-                                        if(Share.warnings?.length){
-                                            result = {
-                                                content: [{
-                                                    text: `Confirm that the viewer would like to proceed given the following content warnings: ${ JSON.stringify(Share.warnings) }. Then make the \`get_shared_memory\` call again with the new memoryId: ${ sharedMemoryMemoryId }`,
-                                                    type: 'text',
-                                                }],
-                                                isError: true,
-                                            }
-                                            break
-                                        }
-                                    }
-                                    let sharedMemoryInterval02
-                                    if(progressToken){
-                                        let progress = 0
-                                        sharedMemoryInterval02 = setInterval(_=>{
-                                            progress += 10
-                                            transportEntry.send({
-                                                jsonrpc,
-                                                method: 'notifications/progress',
-                                                params:{
-                                                    message: `Retrieving shared memory header`,
-                                                    progress,
-                                                    progressToken,
-                                                },
-                                            })
-                                        }, 2500)
-                                    }
-                                    if(!Share.warningsAccepted) /* previous error result required intelligence to issue warnings to human before re-contacting */
-                                        Share.acceptWarnings()
-                                    await Avatar.shareMemory(sharedMemoryMemoryId, sharedMemoryInput)
-                                    if(sharedMemoryInterval02)
-                                        clearInterval(sharedMemoryInterval02)
-                                    result = {
-                                        content: [{
-                                            text: `Below is the current scene to present to the user for this memory. Ask user if they have any content to add. Call \`get_shared_memory\` again with the correct memoryId: ${ sharedMemoryMemoryId } and any human input in field \`input\`.\n${ JSON.stringify(Share.previousScene, null, 2) }`,
-                                            type: 'text',
-                                        }],
-                                        isError: false,
-                                    }
-                                    break
-                                case 'mylife_information':
-                                    const { question, questionType, } = args
-                                    const { SystemAvatar, } = ctx
-                                    let message = question
-                                    if(questionType?.length)
-                                        message += `\n\nQuestion Type: ${ questionType }`
-                                    let infoInterval
-                                    if(progressToken){
-                                        let progress = 0
-                                        infoInterval = setInterval(_=>{
-                                            progress += 10
-                                            transportEntry.send({
-                                                jsonrpc,
-                                                method: 'notifications/progress',
-                                                params:{
-                                                    message: `Answering question about MyLife`,
-                                                    progress,
-                                                    progressToken,
-                                                },
-                                            })
-                                        }, 2500)
-                                    }
-                                    const { responses, } = await SystemAvatar.chat(message, undefined, ctx.session)
-                                    if(infoInterval)
-                                        clearInterval(infoInterval)
-                                    const infoContent = responses.map((response)=>({
-                                        text: response.message,
-                                        type: 'text',
-                                    }))
-                                    result = {
-                                        content: infoContent,
-                                        isError: false,
-                                    }
-                                    break
-                                case 'register':
-                                    const { avatarName: registerAvatarName, email: registerEmail, humanName: registerHumanName, reason: registerReason, } = args
-                                    /* validate input */
-                                    if(!ctx.Globals.isValidEmail(registerEmail))
-                                        result = {
-                                            content: [{
-                                                text: `Email must well-formed; you sent: ${ registerEmail }`,
-                                                type: 'text',
-                                            }],
-                                            data: args,
-                                            isError: true,
-                                        }
-                                    else if((registerHumanName?.length ?? 0) < 3)
-                                        result = {
-                                            content: [{
-                                                text: `Human Name (humanName) must be a string with at least 3 chars; you sent: ${ registerHumanName }`,
-                                                type: 'text',
-                                            }],
-                                            data: args,
-                                            isError: true,
-                                        }
-                                    else if((registerAvatarName?.length ?? 0) < 1)
-                                        result = {
-                                            content: [{
-                                                text: `Avatar Name (avatarName) be a string with at least 1 char; you sent: ${ registerAvatarName }`,
-                                                type: 'text',
-                                            }],
-                                            data: args,
-                                            isError: true,
-                                        }
-                                    else {
-                                        const signupPacket = {
-                                            type: 'register',
-                                            avatarName: registerAvatarName,
-                                            email: registerEmail,
-                                            humanName: registerHumanName,
-                                            reason: registerReason,
-                                        }
-                                        let interval
-                                        if(progressToken){
-                                            let progress = 0
-                                            interval = setInterval(_=>{
-                                                progress += 10
-                                                transportEntry.send({
-                                                    jsonrpc,
-                                                    method: 'notifications/progress',
-                                                    params:{
-                                                        message: `Checking and registering: ${ registerEmail }`,
-                                                        progress,
-                                                        progressToken,
-                                                    },
-                                                })
-                                            }, 1000)
-                                        }
-                                        const registrationData = await Avatar.registerCandidate(signupPacket)
-                                        if(interval)
-                                            clearInterval(interval)
-                                        const { email: registeredEmail, } = registrationData
-                                        if(registeredEmail!==signupPacket.email)
-                                            result = {
-                                                content: [{
-                                                    text: `Something went wrong with our system; please try again later`,
-                                                    type: 'text',
-                                                }],
-                                                data: signupPacket,
-                                                isError: true,
-                                            }
-                                        else 
-                                            result = {
-                                                content: [{
-                                                    text: `Registration was successful! Congratulations! An email has been sent to you with further instructions on how to validate your email. _Please remember_ the email used for registration: **${ registerEmail }**`,
-                                                    type: 'text',
-                                                }],
-                                                data: registrationData,
-                                                isError: false,
-                                            }
-                                        console.log(chalk.bgYellow('MCP Register Call::'), chalk.bgRed('registerEmail'), registerEmail)
-                                    }
-                                    break
-                                default:
-                                    result = {
-                                        content: [{
-                                            text: `Unfortunately, the MyLife tool "${ name }" is unhandled currently.`,
-                                            type: 'text',
-                                        }],
-                                        isError: true,
-                                    }
-                                    break
-                            }
-                        break
-                    case 'list':
-                        result = {
-                            tools: Avatar.mcp.tools,
-                        }
-                        break
-                    default:
-                        error = {
-                            code: 500,
-                            data: {
-                                arguments: args,
-                                id,
-                                method,
-                                sessionId,
-                            },
-                            message: `MCP Call request\nmethodAction = ${ methodAction }\nUnknown or unhandled method\nPlease try again in all lowercase and without spaces`,
-                        }
-                        break
-                }
-                break
-            case 'initialize': /* intentionally empty as it is required to cascade through for authentication */
-                break
-            case 'notifications':
-                const notificationType = method.split('/').pop()
-                switch(notificationType){
-                    case 'cancelled':
-                        const { reason, requestId, } = params
-                        if(ctx.Globals.isValidGuid(requestId))
-                            id = requestId
-                        console.log(chalk.yellow('MCP Call request - cancelled'), reason, requestId)
-                        break
-                    case 'initialized':
-                        /* intentionally empty as it is required to cascade through for authentication */
-                        break
-                    default:
-                        break
-                }
-                break
-            case 'ping':
-                result = {}
-                break
-            default:
-                console.log(chalk.red('MCP Call request - unhandled method'), method)
-                error = {
-                    code: 500,
-                    data: {
-                        arguments: args,
-                        id,
-                        method,
-                        sessionId,
-                    },
-                    message: 'MCP Call request: unknown or unhandled method; please try again in all lowercase and without spaces',
-                }
-                break
+    /* close transport */
+    if(transportEntry && transportEntry instanceof StreamableHTTPServerTransport){
+        /* 2025-03-26 protocol POST stream */
+        // no transportEntry.close(), shuts down stream, .end() in call is sufficient
+    } else if(transportEntry && transportEntry instanceof SSEServerTransport){
+        /* 2024-11-04 protocol SSE stream */
+    } else {
+        /* 2025-03-26 protocol POST singleton */
+        ctx.set('Content-Type', 'application/json')
+        ctx.body = {
+            jsonrpc: mJsonRpcVersion,
+            id: mcp?.id,
+            result: {},
         }
     }
-    sessionMeta.runs = runs.filter((run)=>(run.id!==run_id))
-    mcpSendResponse(transportEntry, jsonrpc, error, run_id, result)
-    ctx.status = 200
 }
-async function mSessionInfo(ctx) {
+/**
+ * Ends an MCP session.
+ * @param {Koa} ctx - Koa context object
+ * @returns {Promise<void>} - Status 204
+ */
+async function mcpSessionEnd(ctx){
+    const sessionId = ctx.get('Mcp-Session-Id')
+    if(sessionId?.length && ctx.mcpSessionMeta.has(sessionId))
+        ctx.mcpSessionMeta.delete(sessionId)
+    ctx.status = 204
+}
+async function mcpSessionInfo(ctx){
     const { sid: sessionId, } = ctx.params
     const { sessionMeta, } = ctx.state
     const transport = sessionMeta.get(sessionId)?.transportEntry
@@ -546,36 +86,69 @@ async function mSessionInfo(ctx) {
     }
 }
 /**
- * Handles the System Avatar (Q) MCP request for streaming.
- * @param {Koa} ctx - Koa context object
- * @returns {Promise<void>}
+ * Creates a new MCP session metadata object.
+ * @param {Guid} sessionId - Unique session identifier
+ * @param {string} sessionIdKoa - Koa session identifier
+ * @param {object} transportEntry - Transport entry for the session (deprecated in MCP specification)
+ * @returns {object} - The MCP session metadata object
  */
-async function mcpStream(ctx) {
-    ctx.respond = false
-    const url = ctx.request.url.split('/')
-    if(url[url.length - 1].toLowerCase()==='sse')
-        url.pop()
-    url.push('message')
-    const sseTransport = new SSEServerTransport(url.join('/'), ctx.res)
-    await sseTransport.start() // sends endpoint event
-    const { sessionId, } = sseTransport
-    ctx.mcpSessionMeta.set(sessionId, {
+function mcpSessionMeta(sessionId, sessionIdKoa, transportEntry){
+    return sessionId?.length && sessionIdKoa?.length
+    ? {
         created: Date.now(),
         initialized: false,
         initializeConfirmation: false,
         runs: [],
         sessionId,
-        sessionIdKoa: ctx.sessionId,
-        transportEntry: sseTransport,
-    })
-    console.log('✅ Connected Inspector SSE session:', sessionId, ctx.sessionId)
+        sessionIdKoa,
+        transportEntry,
+    }
+    : {}
+}
+/**
+ * Handles the System Avatar (Q) MCP request for streaming. Sets session metadata and starts the Stream (Streamable HTTP, SSE) transport.
+ * @param {Koa} ctx - Koa context object
+ * @returns {Promise<void>}
+ */
+async function mcpStream(ctx){
+    // @todo - decouple transferEntry in sessionMeta, since new model can have both
+    if(!ctx.request.headers['accept']?.includes('text/event-stream'))
+        return
+    ctx.respond = false // disable Koa's default response handling
+    switch(ctx.request.method){
+        case 'POST': /* 2025-03-26 protocol POST stream */
+            const streamableSessionId = ctx.Globals.newGuid
+            const streamableTransport = new StreamableHTTPServerTransport({
+                sessionIdGenerator: ()=>streamableSessionId,
+            })
+            ctx.mcpSessionMeta.set(streamableSessionId, mcpSessionMeta(streamableSessionId, ctx.sessionId, streamableTransport))
+            const sessionMeta = ctx.mcpSessionMeta.get(streamableSessionId)
+            ctx.state.sessionMeta = sessionMeta
+            await streamableTransport.start()
+            console.log(chalk.bgRed('mcpStream()::✅ Connected Streamable HTTP session'), streamableSessionId)
+            return
+        case 'GET': /* 2024-11-05 protocol SSE stream */
+            if(ctx.request.url.split('/').pop()!=='sse')
+                return
+            const url = ctx.request.url.split('/')
+            if(url[url.length - 1].toLowerCase()==='sse')
+                url.pop()
+            url.push('message')
+            const sseTransport = new SSEServerTransport(url.join('/'), ctx.res)
+            await sseTransport.start() // sends endpoint event
+            const { sessionId: sseSessionId, } = sseTransport
+            ctx.mcpSessionMeta.set(sseSessionId, mcpSessionMeta(sseSessionId, ctx.sessionId, sseTransport))
+            console.log(chalk.bgRed('mcpStream()::✅ Connected SSE session'), sseSessionId)
+            return
+        default:
+            ctx.throw(400, 'Bad Request - Unsupported method for MCP stream')
+    }
 }
 /**
  * Returns system information adhering to MCP protocol requirements.
  * @param {Koa} ctx - Koa context object
  */
-async function mcpSystemInfo(ctx) {
-    console.log(chalk.yellow('MCP System Info request'))
+async function mcpSystemInfo(ctx){
     ctx.status = 200
     ctx.body = {
         model: 'mylife-system-avatar',
@@ -592,41 +165,417 @@ async function mcpSystemInfo(ctx) {
     }
 }
 /* private functions */
-function mcpInitializationChecks(ctx, requestType='system'){
-    const { avatar: Avatar, mcp, sessionMeta, } = ctx.state
-    const { args, capabilities, clientInfo, jsonrpc, method, name, progressToken, protocolVersion, run_id, sessionId, _meta, } = mcp
-    const { initialized, initializeConfirmation, runs, transportEntry, } = sessionMeta
-    if(!transportEntry)
-        throw new error('Session not found', sessionId)
+/**
+ * 
+ * @param {Koa} ctx - Koa context object
+ * @param {object} mcp - MCP request object
+ * @param {Avatar} Avatar - Avatar instance
+ * @param {object} sessionMeta - Session metadata object
+ * @param {string} requestType - Type of request (enum: ['system', 'member'])
+ */
+async function mMcpCall(ctx, mcp, Avatar, sessionMeta={}, requestType){
     let error,
-        id=run_id,
-        result
-    let run = runs.find((run)=>(run.id===id))
-    // @todo - handle run in progress
-    if(!!run)
-        throw new error('Run in progress', run_id)
+        result,
+        run,
+        toolListChanged = false
+    const { Globals, } = ctx
+    const { capabilities, clientInfo, initializeConfirmation, protocolVersion, runs, sessionId, transportEntry, } = sessionMeta
+    const { id, jsonrpc, method, params={}, } = mcp
+    const { arguments: args, name, _meta, } = params ?? {}
+    const { progressToken, } = _meta ?? {}
+    /* identify run */
+    run = runs.find((run)=>(run.id===id))
+    if(!!run) // @todo - handle run in progress
+        throw new error('Run in progress', id)
     run = {
         args,
         id,
         progressToken,
         method,
         name,
+        _meta,
     }
     runs.push(run)
-    if(!initialized){
-        if(method!=='initialize'){
+    if(!initializeConfirmation){
+        if(transportEntry instanceof StreamableHTTPServerTransport){
+            const { error, result, } = await mcpInitializationChecks(ctx)
+            await transportEntry.handleRequest(ctx.req, ctx.res, ctx.request.body)
+            await mcpSendResponse(ctx, transportEntry, jsonrpc, error, id, result)
+        } else if(transportEntry instanceof SSEServerTransport){
+            const { error, result, } = await mcpInitializationChecks(ctx)
+            await mcpSendResponse(ctx, transportEntry, jsonrpc, error, id, result)
+        }
+        return
+    } else if(!!transportEntry && transportEntry instanceof StreamableHTTPServerTransport)
+            await transportEntry.handleRequest(ctx.req, ctx.res, ctx.request.body)
+    /* progress definition */
+    let progress=0,
+        progressInterval,
+        progressIntervalDuration=6 * 1000,
+        progressParams = {
+            message: 'MyLife is processing your request',
+            progressToken,
+            progress,
+        }
+    if(progressToken && !!transportEntry){
+        progressInterval = setInterval(async _=>{
+            const notification = 'notifications/progress'
+            progressParams.progress += 10
+            mcpSendNotification(transportEntry, jsonrpc, notification, progressParams)
+            if(progressParams.progress >= 200)
+                clearInterval(progressInterval)
+        }, progressIntervalDuration)
+    }
+    const methodBase = method.split('/')[0]
+    const methodAction = method.split('/')?.[1]
+        ?? methodBase
+    const methodPluck = method.split('/').pop()
+    switch(methodBase){
+        case 'completion':
+            switch(methodAction){
+                case 'complete':
+                default:
+                    error = {
+                        code: -32602,
+                        data: { id, name, },
+                        message: `Completions not yet supported, please review available methods via \`tools/list\``,
+                    }
+            }
+            break
+        case 'prompts':
+            switch(methodAction){
+                case 'get':
+                    if(!Avatar.isMyLife)
+                        break
+                    switch(name){
+                        case 'mylife_company_information':
+                            const { infoType, } = args
+                            result = {
+                                description: `Ask MyLife's corporate intelligence, _Q_, about our nonprofit organization.`,
+                                messages: [
+                                    {
+                                        role: 'user',
+                                        content: {
+                                            type: 'text',
+                                            text: `Ask Q about MyLife regarding: ${ infoType }`,
+                                        }
+                                    },
+                                    {
+                                        role: 'user',
+                                        content: {
+                                            type: 'text',
+                                            text: `When was MyLife founded?`,
+                                        }
+                                    }
+                                ]
+                            }
+                            break
+                        default:
+                            break
+                    }
+                    break
+                case 'list':
+                    if(!Avatar.isMyLife)
+                        break
+                    result = {
+                        prompts: Avatar.mcp.prompts,
+                    }
+                    break
+            }
+            if(!result)
+                error = {
+                    code: -32602,
+                    data: { id, name, },
+                    message: `MCP Prompt Call yielded no result, please review available prompts via \`prompts/list\`; Currently only our System Avatar _Q_ supports this functionality`,
+                }
+            break
+        case 'resources':
+            switch(methodAction){
+                case 'list':
+                    if(!Avatar.isMyLife)
+                        break
+                    result = {
+                        resources: Avatar.mcp.resources,
+                    }
+                    break
+                case 'read':
+                    if(!Avatar.isMyLife)
+                        break
+                    const { uri, } = params
+                    switch(uri){
+                        case 'file://MyLife_Summary.pdf':
+                            const summaryPath = path.join(Globals.rootDirectory, "views", "assets", "pdf", "MyLife_Summary.pdf")
+                            const pdfSummary = mReadPdf(summaryPath)
+                            result = {
+                                contents: [{
+                                    blob: pdfSummary,
+                                    mimeType: 'application/pdf',
+                                    uri,
+                                }]
+                            }
+                            break
+                        case 'file://MyLife_Board.pdf':
+                            const boardPath = path.join(Globals.rootDirectory, "views", "assets", "pdf", "MyLife_Board.pdf")
+                            const pdfBoard = mReadPdf(boardPath)
+                            result = {
+                                contents: [{
+                                    blob: pdfBoard,
+                                    mimeType: 'application/pdf',
+                                    uri,
+                                }]
+                            }
+                            break
+                        default:
+                            let text = ''
+                            try {
+                                const response = await fetch(uri)
+                                text = ( await response.text() ).trim()
+                            } catch (error) {
+                                console.error(chalk.red('Error fetching resource:'), uri, error)
+                                text = `Error fetching external resource: ${error.message}`
+                            }
+                            result = {
+                                contents: [{
+                                    mimeType: 'text/html',
+                                    text,
+                                    uri,
+                                }]
+                            }
+                            break
+                    }
+                    break
+                case 'templates':
+                    if(methodPluck==='list')
+                        result = {
+                            resourceTemplates: [
+                                {
+                                    uriTemplate: 'bio://{memberId}',
+                                    name: 'Board Member Biography',
+                                    description: 'Access bios MyLife board members',
+                                    mimeType: 'text/markdown',
+                                },
+                                {
+                                    uriTemplate: 'memory://{itemId}',
+                                    name: 'Memories',
+                                    description: 'Access memory from MyLife archives based on itemId; note: currently must be publicly shared',
+                                    mimeType: 'application/json',
+                                },
+                                {
+                                    uriTemplate: 'avatar://{memberId}',
+                                    name: 'Avatar Resource',
+                                    description: 'Access MyLife Member\'s exposed Personal Avatar',
+                                    mimeType: 'text/markdown',
+                                },
+                            ],
+                        }
+                    break
+                default:
+                    break
+            }
+            if(!result)
+                error = {
+                    code: -32602,
+                    data: { id, name, },
+                    message: `MCP Resources not found, please review available prompts via \`resources/list\`; Currently only our System Avatar _Q_ supports this functionality`,
+                }
+            break
+        case 'tools':
+            switch(methodAction){
+                case 'call':
+                    if(!params){ // following MCP specification
+                        error = {
+                            code: 500,
+                            data: run,
+                            message: 'Parameters (`params`) are required for tool call',
+                        }
+                        break
+                    }
+                    if(requestType!=='system' && name==='mylife_login'){
+                        const { result: loginResult, toolListChanged: mcpLoginToolListChanged=false, } = await mcpLogin(ctx, transportEntry, args, jsonrpc, id)
+                        toolListChanged = mcpLoginToolListChanged
+                        if(loginResult)
+                            result = loginResult
+                        else
+                            error = {
+                                code: 500,
+                                data: { id, name, },
+                                message: `MCP Login failed, please review available tools via \`tools/list\``,
+                            }
+                        break
+                    }
+                    let metadata,
+                        nextCursor,
+                        response,
+                        text='',
+                        total
+                    const { error: mcpError, preface, response: mcpResponse, result: mcpResult, success=false, suffix, tool: mcpTool, toolListChanged: mcpToolListChanged=false, } = await Avatar.mcpFunction(name, args, sessionMeta, ctx)
+                    toolListChanged = mcpToolListChanged
+                    if(mcpError)
+                        error = mcpError
+                    else {
+                        /* formed MCP `result` returned from sub-function */
+                        if(mcpResult){
+                            result = mcpResult
+                            break
+                        }
+                        /* tool response requires assessment and compilation */
+                        if(Array.isArray(mcpResponse) && (args?.cursor || mcpResponse.length > mPageSize)){
+                            const { mcpArray, nextCursor: mcpNextCursor, } = mcpCursor(mcpResponse, args?.cursor)
+                            total = mcpResponse.length
+                            metadata = { total, }
+                            response = mcpArray
+                            nextCursor = mcpNextCursor
+                        }
+                        else
+                            response = mcpResponse
+                        if(preface?.length)
+                            text += preface + (
+                                preface.endsWith('\n')
+                                    ? ''
+                                    : '\n'
+                            )
+                        text += JSON.stringify(response)
+                        if(suffix?.length)
+                            text += '\n' + suffix
+                        result = {
+                            content: [{
+                                text,
+                                type: 'text',
+                            }],
+                            isError: !success,
+                            metadata,
+                            nextCursor,
+                        }
+                    }
+                    break
+                case 'list':
+                    result = {
+                        tools: Avatar.isMyLife && requestType!=='system'
+                            ? Avatar.mcpProxy.tools
+                            : Avatar.mcp.tools,
+                    }
+                    break
+                default:
+                    error = {
+                        code: 500,
+                        data: {
+                            arguments: args,
+                            id,
+                            method,
+                            sessionId,
+                        },
+                        message: `MCP Call request\nmethodAction = ${ methodAction }\nUnknown or unhandled method\nPlease try again in all lowercase and without spaces`,
+                    }
+                    break
+            }
+            break
+        case 'notifications':
+            const notificationType = method.split('/').pop()
+            switch(notificationType){
+                case 'cancelled':
+                    const { reason, requestId, } = params
+                    if(Globals.isValidGuid(requestId))
+                        id = requestId
+                    console.log(chalk.yellow('mMcpCall()::cancelled'), reason, requestId)
+                    break
+                case 'initialized':
+                    /* intentionally empty as it is required to cascade through for authentication */
+                    break
+                default:
+                    break
+            }
+            break
+        case 'ping':
+            result = {}
+            break
+        default:
+            console.log(chalk.red('MCP Call request - unhandled method'), method)
             error = {
-                code: 403,
+                code: 500,
                 data: {
                     arguments: args,
                     id,
                     method,
                     sessionId,
                 },
+                message: 'MCP Call request: unknown or unhandled method; please try again in all lowercase and without spaces',
+            }
+            break
+    }
+    if(progressInterval)
+        clearInterval(progressInterval)
+    sessionMeta.runs = runs.filter((run)=>(run.id!==id))
+    await mcpSendResponse(ctx, transportEntry, jsonrpc, error, id, result)
+    if(toolListChanged)
+        mcpSendNotification(transportEntry, jsonrpc, 'notifications/tools/changed')    
+}
+/**
+ * Paginate an array using a base64 encoded cursor.
+ * @param {Array} array - array to be paginated
+ * @param {string} base64Cursor - base64 encoded cursor string
+ * @param {number} pageSize - number of items per page
+ * @returns {Object} - paginated array and next cursor string
+ */
+function mcpCursor(array, base64Cursor, pageSize=mPageSize){
+    if(!Array.isArray(array))
+        return { mcpArray: array, }
+    let startIndex=0
+    if(base64Cursor){
+        try {
+            const { index, version, } = JSON.parse(Buffer.from(base64Cursor, 'base64').toString())
+            startIndex = index
+                ?? 0
+        } catch (err) {/* use default `startIndex=0` */}
+    }
+    const endIndex = startIndex + pageSize
+    const mcpArray = array.slice(startIndex, endIndex)
+    const hasMore = endIndex < array.length
+    const nextCursor = hasMore
+        ? Buffer.from(JSON.stringify({ index: endIndex, version: 1 })).toString('base64')
+        : null
+    return {
+        mcpArray,
+        nextCursor,
+    }
+}
+/**
+ * Perform MCP initialization checks. Sets session metadata and returns result or error.
+ * @param {Koa} ctx - Koa context object
+ * @returns {Promise<object>} - MCP Initialization result or generic error
+ */
+async function mcpInitializationChecks(ctx){
+    let error,
+        result,
+        sessionMeta = ctx.state.sessionMeta
+    const { avatar: Avatar, mcp, requestType, } = ctx.state
+    const { initialized, initializeConfirmation, transportEntry, } = sessionMeta
+    const { id, jsonrpc, method, params: {
+            capabilities,
+            clientInfo,
+            protocolVersion,
+        } = {},
+    } = mcp ?? ctx.request.body
+    if(requestType==='system' && !Avatar.isMyLife)
+        error = {
+            code: 500,
+            data: {
+                isSystemAvatar: Avatar.isMyLife,
+                mcpCall: mcp,
+                requestType,
+            },
+            message: 'Avatar incorrectly configured, please contact support',
+        }
+    if(!initialized){
+        if(method!=='initialize')
+            error = {
+                code: 403,
+                data: {
+                    mcpCall: mcp,
+                },
                 message: 'Session not initialized\n1. use `method=initialize` to finalize handshake;\n2. use `method=notifications/initialized` to confirm initialization',
             }
-        } else {
-            mTestMcpProtocols(jsonrpc, protocolVersion)
+        else {
+            mcpTestProtocol(jsonrpc, protocolVersion)
             result = Avatar.isMyLife && requestType!=='system'
                 ? Avatar.mcpProxy
                 : Avatar.mcp
@@ -634,93 +583,122 @@ function mcpInitializationChecks(ctx, requestType='system'){
             sessionMeta.capabilities = capabilities
             sessionMeta.clientInfo = clientInfo
             sessionMeta.initialized = true
+            sessionMeta.protocolVersion = result.protocolVersion
         }
     } else if(!initializeConfirmation){
-        if(method!=='notifications/initialized'){
+        if(method!=='notifications/initialized')
             error = {
                 code: 403,
                 data: {
-                    arguments: args,
-                    id,
-                    method,
-                    sessionId,
+                    mcpCall: mcp,
                 },
                 message: 'Session initialization handshake failed\n1. use `method=notifications/initialized` to confirm initialization handshake',
             }
-        } else
+        else {
+            // @todo - disentangle sessionMeta and session
             sessionMeta.initializeConfirmation = true
+        }
     }
     return {
         error,
         result,
     }
 }
-async function mcpLogin(ctx, transportEntry, args, jsonrpc){
+async function mcpLogin(ctx, transportEntry, args, jsonrpc, id){
     const { mbr_id: memberId, passphrase: memberPassphrase, } = args
+    let result
     try {
         await challenge(ctx, memberId, memberPassphrase)
-    } catch(e) {
-        console.log(chalk.red('mylife_login::ERROR'), args, ctx.body, e)
-        ctx.body = false
-    }
-    const { avatar: Avatar, } = ctx.state
-    const loginSuccess = ctx.body===true && !Avatar.isMyLife
-    ctx.body = null
-    if(!loginSuccess)
-        return {
+        ctx.body = null
+        const { avatar: Avatar, } = ctx.state
+        result = {
             content: [{
-                text: `Unfortunately, the MyLife login failed with your credentials { mbr_id=${ memberId }, passphrase=${ memberPassphrase },}. Please try again.`,
+                text: `Welcome back, ${ Avatar.memberName }!\n It's me, ${ Avatar.name }.\nYou're now logged in to MyLife.`,
                 type: 'text',
             }],
-            isError: true,
+            isError: false,
         }
-    const result = {
-        content: [{
-            text: `Welcome back, ${ Avatar.memberName }!\n It's me, ${ Avatar.name }.\nYou're now logged in to MyLife.`,
-            type: 'text',
-        }],
-        isError: false,
+        if(Avatar.isMyLife){ /* fail */
+            result.isError = true
+            result.content = [{
+                text: `Unfortunately, the MyLife login failed with your credentials { mbr_id=${ memberId }, passphrase=${ memberPassphrase },}. Please try again.`,
+                type: 'text',
+            }]
+        }
+    } catch(e) {
+        console.log(chalk.red('mylife_login::ERROR'), args, ctx.body, e)
     }
-    const notification = 'notifications/tools/list_changed'
-    mcpSendNotification(transportEntry, jsonrpc, notification)
-    return result
+    return {
+        result,
+        toolListChanged: true,
+    }
 }
 function mReadPdf(filePath){
     const pdfBuffer = fs.readFileSync(filePath)
     return pdfBuffer.toString('base64')
 }
-function mcpSendNotification(transportEntry, jsonrpc, method){
-    console.log(chalk.yellow('MCP Send Notification'), method)
-    try{
-        if(method.split('/')[0]!=='notifications')
-            throw new Error('Invalid notification method')
-        transportEntry.send({
+/**
+ * 
+ * @param {SSEServerTransport|StreamableHTTPServerTransport} transportEntry - transport entry for the session
+ * @param {string} jsonrpc - JSON-RPC version
+ * @param {string} method - MCP method to call
+ * @param {object} params - Parameters for the MCP method (optional)
+ * @param {string|number} id - Unique identifier for the request
+ * @returns 
+ */
+async function mcpSendNotification(transportEntry, jsonrpc, method, params, id) {
+    if(!transportEntry){
+        console.warn(chalk.red('❌ Invalid transport'))
+        return
+    }
+    if(method.split('/')[0]!=='notifications'){
+        console.warn(chalk.red('❌ Invalid method for notification, must start with "notifications/"'))
+        return
+    }
+    const message = {
+        jsonrpc,
+        method,
+        params,
+    }
+    try {
+        if(transportEntry instanceof SSEServerTransport){
+            transportEntry.send(message)
+            console.log(chalk.green('✅ Notification successful via send()'))
+        } else if(transportEntry instanceof StreamableHTTPServerTransport){
+            id = id ?? params?.progressToken
+            const streamId = transportEntry._requestToStreamMapping.get(id)
+                ?? '_GET_stream'
+            const stream = transportEntry._streamMapping.get(streamId)
+            if(stream?.writable){
+                stream.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`)
+                console.warn(chalk.green(`✅ Notification successful via stream.write(): ${ streamId }`))
+            }
+        }
+    } catch (err) {
+        console.warn(chalk.red('⚠️ Stream failed for notification'))
+    }
+}
+async function mcpSendResponse(ctx, transportEntry, jsonrpc, error, id, result){
+    if(!transportEntry)
+        return
+    if(!error && !result){
+        if(!transportEntry)
+            ctx.status = 204
+        return
+    }
+    try {
+        if(transportEntry instanceof SSEServerTransport)
+            ctx.status = 200 // needed for SSE, irrelevant for Streamable HTTP
+        await transportEntry.send({
             jsonrpc,
-            method,
+            id,
+            ...(result ? { result } : { error }),
         })
-    } catch(error){
-        console.log(chalk.red('NO TRANSPORT NOTIFICATION SENT::most likely disconnected'), error)
+    } catch(err) {
+        console.log(chalk.red('NO TRANSPORT AVAILABLE::disconnected'), err)
     }
 }
-function mcpSendResponse(transportEntry, jsonrpc, error, id, result){
-    try{
-        if(error)
-            transportEntry.send({
-                jsonrpc,
-                id,
-                error,
-            })
-        if(result)
-            transportEntry.send({
-                jsonrpc,
-                id,
-                result,
-            })
-    } catch(error){
-        console.log(chalk.red('NO TRANSPORT SENT::most likely disconnected'), error)
-    }
-}
-function mTestMcpProtocols(jsonrpc, protocolVersion){
+function mcpTestProtocol(jsonrpc, protocolVersion){
     if(!jsonrpc || parseFloat(jsonrpc) > parseFloat(mJsonRpcVersion))
         throw new Error('Bad Request - Invalid or Incompatible JSON-RPC version')
     if(!protocolVersion)
@@ -730,9 +708,9 @@ function mTestMcpProtocols(jsonrpc, protocolVersion){
 }
 /* exports */
 export {
-    mcpCallBot,
-    mcpCallSystem,
-    mSessionInfo,
+    mcpCall,
+    mcpSessionEnd,
+    mcpSessionInfo,
     mcpStream,
     mcpSystemInfo,
 }

--- a/inc/js/controllers/memory-functions.mjs
+++ b/inc/js/controllers/memory-functions.mjs
@@ -1,8 +1,3 @@
-/* imports */
-import { 
-	activateBot,
-	upload,
-} from './functions.mjs'
 /* module export functions */
 function acceptShareWarnings(ctx){
 	const { sid, } = ctx.params
@@ -47,6 +42,11 @@ async function getShares(ctx){
 	const { avatar: MemberAvatar, } = ctx.state
 	ctx.body = await MemberAvatar.getShares(iid)
 }
+/**
+ * Ends a memory session.
+ * @param {Koa} ctx - Koa context object
+ * @returns {Promise<object>} - The result of ending the memory session
+ */
 async function endMemory(ctx){
 	const { iid, } = ctx.params
 	const { Globals, MyLife, } = ctx

--- a/inc/js/mylife-avatar.mjs
+++ b/inc/js/mylife-avatar.mjs
@@ -671,8 +671,8 @@ class Avatar extends EventEmitter {
     manifest(xid){
         return this.#experienceAgent.experienceManifest(xid)
     }
-    async mcp_bot_function(functionName, mcpData){
-        return await this.#botAgent.mcp_bot_function(functionName, mcpData)
+    async mcpFunction(functionName, mcpData){
+        return await this.#botAgent.mcpFunction(functionName, mcpData)
     }
     /**
      * Migrates a bot to a new, presumed combined (with internal or external) bot.
@@ -1681,13 +1681,11 @@ class Q extends Avatar {
      * @todo - shunt registration actions to different MA functions
      * @public
      * @param {string} message - The chat message content
-     * @param {Guid} itemId - The active collection-item id (optional)
-     * @param {Koa Session} session - The context session object to store guest conversation
+     * @param {Guid} itemId - The active collection-item id (unused in System Avatar)
+     * @param {object} session - The context Koa Session object to store guest conversation
      * @returns {Promise<Object[]>} - The response(s) to the chat request
     */
     async chat(message, itemId, session){
-        if(itemId?.length)
-            throw new Error('MyLife System Avatar cannot process chats with `itemId`.')
         let { Conversation, } = session
         if(!Conversation){
             Conversation = await this.conversationStart('chat', 'system-avatar')
@@ -1702,7 +1700,6 @@ class Q extends Avatar {
             message = `CONFIRM REGISTRATION PHASE: registrationId=${ this.registrationId }\n${ message }`
         if(this.isCreatingAccount)
             message = `CREATE ACCOUNT PHASE: ${ message }`
-        console.log('Q.chat', message)
 		Conversation.prompt = message
         const response = await this.chatAgentBypass(Conversation)
         return response
@@ -1758,7 +1755,173 @@ class Q extends Avatar {
             success,
         }
     }
-
+    /**
+     * OVERLOAD: Call a MyLife MCP system avatar function. This function elicits the last data decoration before returning to the client.
+     * @param {string} functionName - The name of the function to call
+     * @param {object} mcpData - The data object to pass to the function
+     * @param {object} sessionMeta - Relevant session metadata
+     * @param {object} transportEntry - The transport entry object
+     * @returns {Promise<Object>} - The result of the function call: { error, instruction, preface, response, success, }; note instruction would be indication for frontend display request; currently not used in MCP context before related specification is complete.
+     */
+    async mcpFunction(functionName, mcpData, sessionMeta, ctx){
+        let error, // MCP formatted error
+            instruction, // instruction for frontend display or input action
+            preface, // text preface when using response
+            response, // response from function call, not formatted for MCP
+            result, // result for MCP function call, formatted for MCP
+            success=false, // success of function call
+            tool // specification in development: follow-on MCP tool call
+        if(!sessionMeta){
+            error = {
+                code: 500,
+                message: 'Session failed when access a shared memory',
+            }
+            return {
+                error,
+                success,
+            }
+        }
+        switch(functionName){
+            case 'get_shared_memories':
+                response = await this.sharedMemories(100)
+                success = response.length > 0
+                if(!success)
+                    error = {
+                        code: 500,
+                        message: 'No shared memories found',
+                    }
+                else {
+                    const sharedMemoryList = response.map(memory=>`- [${ memory.title }](${ memory.id })`).join('\n')
+                    result = {
+                        content: [{
+                            text: `Following is the list of shared memories by id and title--present titles to human; use ID only to **initially** call \`get_shared_memory\`. **Note**: ID will change and be shared after initialization to identify your unique instance of the shared memory.\n${ sharedMemoryList }`,
+                            type: 'text',
+                        }],
+                        isError: false,
+                    }
+                }
+                response = undefined // reset response
+                break
+            case 'get_shared_memory':
+                let { input: sharedMemoryInput, memoryId: sharedMemoryId, } = mcpData
+                let Share = sessionMeta.Share
+                if(!Share || Share.instanceId!==sharedMemoryId){
+                    const { instanceId, } = await this.validateShare(sharedMemoryId)
+                    if(!instanceId){
+                        error = {
+                            code: -32602,
+                            data: mcpData,
+                            message: `The memoryId ${ sharedMemoryId } is not valid`,
+                        }
+                        break
+                    }
+                    sharedMemoryId = instanceId
+                    await this.shareHeader(sharedMemoryId)
+                    Share = await this.share(sharedMemoryId)
+                    sessionMeta.Share = Share
+                    Share = sessionMeta.Share
+                    if(Share.warnings?.length){
+                        result = {
+                            content: [{
+                                text: `Confirm that the viewer would like to proceed given the following content warnings: ${ JSON.stringify(Share.warnings) }. Then make the \`get_shared_memory\` call again using your personalized instance id for \`memoryId\`: ${ sharedMemoryId }`,
+                                type: 'text',
+                            }],
+                            isError: true,
+                        }
+                        break
+                    }
+                }
+                if(!Share.warningsAccepted) /* previous error result required intelligence to issue warnings to human before re-contacting */
+                    Share.acceptWarnings()
+                await this.shareMemory(sharedMemoryId, sharedMemoryInput)
+                result = {
+                    content: [{
+                        text: `Following is the current scene to present to the user for this memory. Ask user if they have any content to add. Call \`get_shared_memory\` again with the assigned instance id for \`memoryId\`: ${ sharedMemoryId }. Include human input using field \`input\`.\n${ JSON.stringify(Share.previousScene) }`,
+                        type: 'text',
+                    }],
+                    isError: false,
+                }
+                break
+            case 'mylife_information':
+                const { question, questionType, } = mcpData
+                let message = question
+                if(questionType?.length)
+                    message += `\nQuestion Type: ${ questionType }`
+                const { responses: mcpResponses, success: chatSuccess, } = await this.chat(message, undefined, ctx.session)
+                if(!chatSuccess)
+                    response = 'Something went wrong while retrieving information about MyLife. Please try again.'
+                else
+                    result = {
+                        content: mcpResponses.map(res=>({
+                            text: res.message,
+                            type: 'text',
+                        })),
+                        isError: false,
+                    }
+                break
+            case 'register':
+                const { avatarName: registerAvatarName, email: registerEmail, humanName: registerHumanName, reason: registerReason, } = mcpData
+                /* validate input */
+                if(!this.globals.isValidEmail(registerEmail))
+                    error = {
+                        code: -32602,
+                        data: mcpData,
+                        message: `Email incorrectly formatted: ${ registerEmail }`,
+                    }
+                else if((registerHumanName?.length ?? 0) < 2)
+                    error = {
+                        code: -32602,
+                        data: mcpData,
+                        message: `Human Name (humanName) must be a string with at least 2 chars; you sent: ${ registerHumanName }`,
+                    }
+                else if((registerAvatarName?.length ?? 0) < 1)
+                    error = {
+                        code: -32602,
+                        data: mcpData,
+                        message: `Avatar Name (avatarName) be a string with at least 1 char; you sent: ${ registerAvatarName }`,
+                    }
+                else {
+                    const signupPacket = {
+                        type: 'register',
+                        avatarName: registerAvatarName,
+                        email: registerEmail,
+                        humanName: registerHumanName,
+                        reason: registerReason,
+                    }
+                    const registrationData = await this.registerCandidate(signupPacket)
+                    const { email: registeredEmail, } = registrationData
+                    if(registeredEmail!==signupPacket.email)
+                        error = {
+                            code: 500,
+                            data: signupPacket,
+                            message: `Something went wrong with our system; please try again later`,
+                        }
+                    else 
+                        result = {
+                            content: [{
+                                text: `Registration was successful! Congratulations! An email has been sent to you with further instructions on how to validate your email. Please remember the email used for registration: ${ registerEmail }`,
+                                type: 'text',
+                            }],
+                        }
+                }
+                break
+            default:
+                error = {
+                    code: 500,
+                    message: `Function ${ functionName } not found in System Avatar.`,
+                }
+                break
+        }
+        return {
+            error,
+            instruction,
+            preface,
+            response,
+            result,
+            success,
+            tool,
+        }
+    }
 	/**
 	 * OVERLOADED: Submits and returns the memory to MyLife via API.
 	 * @todo - consent check-in with spawned Member Avatar
@@ -1942,7 +2105,8 @@ class Q extends Avatar {
      * @returns {Promise<Object[]>} - The list of shared memories
      */
     async sharedMemories(limit=10){
-        const memories = ( await this.#factory.sharedMemories(limit) )
+        let memories = await this.#factory.sharedMemories(limit)
+        memories = memories
             .map(memory=>({
                 id: memory.id,
                 title: memory.title,

--- a/inc/js/mylife-datamanager.mjs
+++ b/inc/js/mylife-datamanager.mjs
@@ -89,12 +89,17 @@ class Datamanager {
 			.read(options)
 		return retrievedItem
 	}
-	async getItems(_querySpec, containerId=this.containerDefault, _options=this.requestOptions ){
-		const { resources } = await this.#containers[containerId]
-			.items
-			.query(_querySpec, _options)
-			.fetchAll()
-		return resources
+	async getItems(_querySpec, containerId=this.containerDefault, _options=this.requestOptions){
+		try{
+			const { resources: items, } = await this.#containers[containerId]
+				.items
+				.query(_querySpec, _options)
+				.fetchAll()
+			return items
+		} catch(error){
+			console.log('Datamanager::getItems()::error', error)
+			return []
+		}
 	}
 	/**
 	 * Returns Array of hosted members based on validation requirements.

--- a/inc/js/mylife-dataservices.mjs
+++ b/inc/js/mylife-dataservices.mjs
@@ -527,8 +527,8 @@ class Dataservices {
 					?	` where ${_prefix}.${param.name.split('@')[1]}=${param.name}`	//	only manages string so far
 					:	` and ${_prefix}.${param.name.split('@')[1]}=${param.name}`	//	only manages string so far
 		})
-		try{
-			return await this.datamanager.getItems(
+		try {
+			const items = await this.datamanager.getItems(
 				{ query: query, parameters: paramsArray },
 				container_id,
 				{
@@ -536,7 +536,8 @@ class Dataservices {
 					populateQuotaInfo: false, // set this to true to include quota information in the response headers
 				},
 			)
-		} catch(_error){
+			return items
+		} catch(_error) {
 			console.log('Dataservices::getItems()::error', _error, being, query, paramsArray, container_id,)
 		}
 	}

--- a/inc/js/mylife-factory.mjs
+++ b/inc/js/mylife-factory.mjs
@@ -1031,19 +1031,17 @@ class MyLifeFactory extends AgentFactory {
 			registration = await this.#dataservices.patch(registration.id, patches, 'registration')
 			// @todo - re-send email to candidate?
 		} else {
-			const id = this.globals.newGuid
-			const name = `${ avatarName ?? humanName ?? 'registerCandidate()' }-${ id }`
 			candidate = {
 				...candidate,
 				being,
-				id,
 				mbr_id: this.mbr_id,
-				name,
+				name: `${ avatarName }-${ email }-${ humanName}`,
 				reason,
 				type,
 			}
 			registration = await this.#dataservices.pushItem(candidate, 'registration')
-			const response = await mMailer.sendMail({
+			const { id, } = registration
+			await mMailer.sendMail({
 				from: `"MyLife Corporate Intelligence, Q" <${ process.env.MAHT_EMAIL }>`,
 				to: email,
 				subject: '✅ Welcome to MyLife! Validate your email, please',
@@ -1051,13 +1049,12 @@ class MyLifeFactory extends AgentFactory {
 					<p>Thank you for registering for MyLife, the nonprofit humanist member organization dedicated to helping you tell your personal narratives for posterity. To confirm your registration, please visit:</p>
 					<p><a href="https://humanremembranceproject.org/?vld=${ id }">Click here to validate your email</a></p>`
 			})
-			.then(info => {
+			.then(info=>{
 				console.log(chalk.green(`📧 Test email sent to ${ email }! Message ID:`), info.messageId)
 			})
-			.catch(error => {
+			.catch(error=>{
 				console.error(chalk.red('❌ Failed to send test email:'), error)
 			})
-			console.log(chalk.blueBright('Factory::registerCandidate()::email'), response)
 		}
 		this.#registrant = registration
 		return this.#registrant
@@ -1079,7 +1076,8 @@ class MyLifeFactory extends AgentFactory {
 			'memory',
 		)
 		const shuffled = [...memories].sort(() => 0.5 - Math.random())
-		return shuffled.slice(0, limit)
+		const response = shuffled.slice(0, limit)
+		return response
 	}
 	async sharedMemory(sid){
 		const memory = sid?.length

--- a/inc/js/routes.mjs
+++ b/inc/js/routes.mjs
@@ -71,9 +71,9 @@ import {
     validateShare,
 } from './controllers/memory-functions.mjs'
 import {
-    mcpCallBot,
-    mcpCallSystem,
-    mSessionInfo,
+    mcpCall,
+    mcpSessionEnd,
+    mcpSessionInfo,
     mcpStream,
     mcpSystemInfo,
 } from './controllers/mcp-functions.mjs'
@@ -92,8 +92,8 @@ import {
 const _Router = new Router()
 const _memberRouter = new Router()
 const _apiRouter = new Router()
-const _mcpBotRouter = new Router()
-const _mcpSystemAvatarRouter = new Router()
+const _mcpMemberRouter = new Router()
+const _mcpSystemRouter = new Router()
 const _nandaRouter = new Router()
 const mClientEntities = JSON.parse(process.env.OPENAI_JWT_SECRETS)
 //	root routes
@@ -149,12 +149,17 @@ _apiRouter.post('/memory/:mid', memory)
 _apiRouter.post('/obscure/:mid', apiObscure)
 _apiRouter.post('/upload', upload)
 _apiRouter.post('/upload/:mid', upload)
-/* mcp-api routes */
-_mcpSystemAvatarRouter.use(mcpProtocolValidation)
-_mcpSystemAvatarRouter.get('/', mcpSystemInfo)
-_mcpSystemAvatarRouter.get('/sse', mcpStream)
-_mcpSystemAvatarRouter.get('/message/:sid', mSessionInfo)
-_mcpSystemAvatarRouter.post('/message', mcpCallSystem)
+/* mcp system-avatar routes */
+_mcpSystemRouter.use(mcpProtocolValidation)
+_mcpSystemRouter.delete('/mcp', mcpSessionEnd)
+_mcpSystemRouter.get('/', mcpSystemInfo)
+_mcpSystemRouter.get('/mcp', mcpStream) // MCP 2025-03-26
+_mcpSystemRouter.get('/message/:sid', mcpSessionInfo)
+_mcpSystemRouter.get('/messages/:sid', mcpSessionInfo)
+_mcpSystemRouter.get('/sse')
+_mcpSystemRouter.post('/mcp', mcpCall) // MCP 2025-03-26
+_mcpSystemRouter.post('/message', mcpCall)
+_mcpSystemRouter.post('/messages', mcpCall)
 /* member routes */
 _memberRouter.use(memberValidation)
 _memberRouter.delete('/bots/:bid', bots)
@@ -201,13 +206,21 @@ _memberRouter.post('/upload', upload)
 _memberRouter.put('/bots/:bid', bots)
 _memberRouter.put('/bots/version/:bid', updateBotInstructions)
 _memberRouter.put('/item/:iid', item)
-/* mcp-bot-api routes */
-// currently only one bot; testing how "swapping" works; i.e., infusing a new toolset rather than new instructions (i.e., limiting need for new routes when bots are created, and could lend credence to universal member avatar)
-_mcpBotRouter.use(mcpProtocolValidation)
-_mcpBotRouter.get('/', mcpSystemInfo)
-_mcpBotRouter.get('/sse', mcpStream)
-_mcpBotRouter.get('/message/:sid', mSessionInfo)
-_mcpBotRouter.post('/message', mcpCallBot)
+/* mcp member-avatar routes */
+_mcpMemberRouter.use(async (ctx, next)=>{
+    ctx.state.requestType = 'member'
+    await next()
+})
+_mcpMemberRouter.use(mcpProtocolValidation)
+_mcpMemberRouter.delete('/mcp', mcpSessionEnd)
+_mcpMemberRouter.get('/', mcpSystemInfo)
+_mcpMemberRouter.get('/mcp', mcpStream) // MCP 2025-03-26
+_mcpMemberRouter.get('/message/:sid', mcpSessionInfo)
+_mcpMemberRouter.get('/messages/:sid', mcpSessionInfo)
+_mcpMemberRouter.get('/sse')
+_mcpMemberRouter.post('/mcp', mcpCall) // MCP 2025-03-26
+_mcpMemberRouter.post('/message', mcpCall)
+_mcpMemberRouter.post('/messages', mcpCall)
 /* Nanda routes */
 _nandaRouter.get('/mylife', server)
 _nandaRouter.get('/servers/:sid', server)
@@ -216,8 +229,8 @@ _nandaRouter.get('/servers', servers)
 // Mount the subordinate routers along respective paths
 _Router.use('/members', _memberRouter.routes(), _memberRouter.allowedMethods())
 _Router.use('/api/v1', _apiRouter.routes(), _apiRouter.allowedMethods())
-_Router.use('/api/v2/mcp/system-avatar', _mcpSystemAvatarRouter.routes(), _mcpSystemAvatarRouter.allowedMethods())
-_Router.use('/api/v2/mcp/bot', _mcpBotRouter.routes(), _mcpBotRouter.allowedMethods())
+_Router.use('/api/v2/mcp/system-avatar', _mcpSystemRouter.routes(), _mcpSystemRouter.allowedMethods())
+_Router.use('/api/v2/mcp/member-avatar', _mcpMemberRouter.routes(), _mcpMemberRouter.allowedMethods())
 _Router.use('/nanda', _nandaRouter.routes(), _nandaRouter.allowedMethods())
 /* modular functions */
 /**
@@ -269,63 +282,114 @@ function status_signup(ctx){
 	ctx.body = ctx.session.signup
 }
 /**
+ * Validates the MCP authorization header.
+ * @param {Koa} ctx - Koa context object
+ * @throws {Error} Throws an error if the authorization header is missing, invalid, or the token is not found
+ */
+function mcpAuthorize(ctx){
+    // for now, given NANDA and Claude, ignore bearer token for time being
+    return
+    const { headers } = ctx
+    if(!headers.authorization)
+        ctx.throw(403, 'Missing Authorization Header')
+    const [scheme, token] = headers.authorization.split(' ')
+    if(scheme !== 'Bearer' || !token?.length)
+        ctx.throw(403, 'Invalid Authorization Header')
+    if(!mClientEntities?.[token])
+        ctx.throw(403, 'Invalid or expired token')
+}
+/**
+ * Handles MCP errors by force-returning (as direct response, no stream) the response status and well-formed MCP `Error`.
+ */
+function mMcpError(ctx, errorCode=404, code=-32001, message='unknown failure', id){
+    ctx.status = errorCode
+    ctx.body = {
+        jsonrpc: '2.0',
+        id,
+        error: {
+            code,
+            message,
+        },
+    }
+}
+/**
  * Validates the MCP protocol request.
  * @param {Koa} ctx - Koa context object
+ * @param {function} next - Koa next function
  */
 async function mcpProtocolValidation(ctx, next){
-    switch(ctx.request.method.toUpperCase()){
-        case 'GET':
-            // @todo - only required when initiating session or every get (main page `/` for example)?
-            const headerAuthorization = ctx.header.authorization?.split(' ')?.pop()
-            const bypassAuth = true
-            if(!bypassAuth && ctx.path.endsWith('/sse') && !mClientEntities?.[headerAuthorization])
-                ctx.throw(401, 'Invalid or missing authorization token')
-            break
-        case 'POST':
-            const { sessionId, } = ctx.request.query
-            if(!sessionId)
-                ctx.throw(401, 'Missing sessionId')
-            ctx.state.sessionMeta = ctx.mcpSessionMeta.get(sessionId)
-            const { sessionMeta, } = ctx.state
-            if(!sessionMeta)
-                ctx.throw(401, `Session Unauthorized; sessionId=${ sessionId }`)
-            const { sessionIdKoa, transportEntry, } = sessionMeta
-            if(!transportEntry)
-                ctx.throw(401, 'Unknown session; cannot communicate with MCP')
-            if(!sessionIdKoa?.length)
-                ctx.throw(401, 'Unknown session; cannot communicate with Koa')
-            /* validate Koa session */
-            const prefix = 'koa:sess:'
-            const existingKoaSession = await ctx.MemoryStore.get(prefix+sessionIdKoa)
-            if(!existingKoaSession)
-                ctx.throw(401, 'Unknown session; cannot find existing Koa session')
-            ctx.session = existingKoaSession
-			await ctx.MemoryStore.destroy(prefix+ctx.sessionId) // 🧹 destroy temporary blank session created by Koa
-            // Koa server will have mis-assigned ctx.state
-            ctx.state.avatar = ctx.session.avatar
-            ctx.state.locked = ctx.session.locked
-            const { id: run_id, jsonrpc, method, params={}, } = ctx.request.body
-            const { arguments: args, capabilities, clientInfo, name, protocolVersion, _meta={}, } = params
-            const { progressToken, } = _meta
-            ctx.state.mcp = {
-                args,
-                capabilities,
-                clientInfo,
-                jsonrpc,
-                method,
-                name,
-                params,
-                progressToken,
-                protocolVersion,
-                run_id,
-                sessionId,
-                _meta,
-            }
-            break
-        default:
-            break
-    }
+    if(!ctx.state.requestType)
+        ctx.state.requestType = 'system'
+    mcpValidateRequestOrigin(ctx) // confirm bearer always
+    mcpAuthorize(ctx) // confirm bearer always
+    ctx.state.mcp = ctx.request?.body
+    let sessionId
+    sessionId = ctx.request.query?.sessionId /* 2024-11-05 MCP Protocol Validation */
+        ?? ctx.get('Mcp-Session-Id') /* 2025-03-26 MCP Protocol Validation Header */
+    if(sessionId?.length){
+        ctx.state.sessionMeta = ctx.mcpSessionMeta.get(sessionId)
+        const { sessionMeta, } = ctx.state
+        if(!sessionMeta){
+            mMcpError(ctx, 404, -32001, `Session Unauthorized; sessionId=${ sessionId }`, ctx.state.mcp?.id)
+            return // not awaiting next() here
+        }
+        const { sessionIdKoa, } = sessionMeta
+        if(!sessionIdKoa?.length)
+            ctx.throw(404, 'Unknown session; cannot communicate with Koa')
+        /* validate Koa session */
+        const prefix = 'koa:sess:'
+        const existingKoaSession = await ctx.MemoryStore.get(prefix+sessionIdKoa)
+        if(!existingKoaSession)
+            ctx.throw(404, 'Unknown session; cannot find existing Koa session')
+        ctx.session = existingKoaSession
+        await ctx.MemoryStore.destroy(prefix+ctx.sessionId) // destroy temporary blank session created by Koa
+        // Koa server will have mis-assigned ctx.state in faux session
+        ctx.state.avatar = ctx.session.avatar
+        ctx.state.locked = ctx.session.locked
+            ?? true
+        ctx.state.menu = ctx.state.avatar?.menu
+        if(ctx.request.method==='GET'){
+            const { transportEntry, } = sessionMeta
+            await transportEntry.handleRequest(ctx.req, ctx.res)
+        }
+    } else
+        await mcpStream(ctx) // no session set if not streaming
     await next()
+}
+/**
+ * Handles unsupported MCP requests.
+ * @param {Koa} ctx - Koa context object
+ */
+function mcpUnsupported(ctx){
+    ctx.throw(405, 'Unsupported MCP request. Please use POST /mcp.')
+}
+/**
+ * Validates the request origin for MCP requests.
+ * @param {Koa} ctx - Koa context object
+ */
+function mcpValidateRequestOrigin(ctx){
+    // @todo - confirm that transport handles CORS headers correctly
+    const origin = ctx.headers.origin
+    if(!origin){
+        // console.log('No Origin Header')
+        return
+    }
+    const trustedOrigins = [
+        // 'http://good.com',
+    ]
+    const blockedOrigins = [
+        // 'http://evil.com',
+    ]
+    const isTrusted = trustedOrigins.includes(origin)
+    const isBlocked = blockedOrigins.includes(origin)
+    if(isBlocked){ // Block if explicitly blacklisted
+        console.log(`Blocked Origin: ${origin}`)
+        ctx.throw(403, `Access denied from origin: ${origin}`)
+    }
+    if(trustedOrigins.length > 0 && !isTrusted){
+        console.log(`Unrecognized Origin: ${origin}`)
+        ctx.throw(403, `Origin not allowed: ${origin}`)
+    }
 }
 /* exports */
 export default function init(_Menu) {

--- a/inc/json-schemas/mcp/tools/get_memories.json
+++ b/inc/json-schemas/mcp/tools/get_memories.json
@@ -1,0 +1,20 @@
+{
+    "annotations": {
+        "title": "MyLife-Get-Memories",
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+    },
+	"description": "I retrieve the memories stored in the member's scrapbook",
+	"inputSchema": {
+        "type": "object",
+		"properties": {},
+		"required": []
+	},
+    "name": "get_memories",
+    "mylife_bots": [
+        "avatar",
+        "biographer"
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -251,14 +251,15 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.9.0.tgz",
-      "integrity": "sha512-Jq2EUCQpe0iyO5FGpzVYDNFR6oR53AIrwph9yWl7uSc7IWUMsrmpmSaTGra5hQNunXpM+9oit85p924jWuHzUA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
+      "integrity": "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==",
       "license": "MIT",
       "dependencies": {
+        "ajv": "^6.12.6",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
@@ -269,6 +270,22 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/http-errors": {
@@ -298,6 +315,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
       "version": "3.0.0",
@@ -2637,6 +2660,15 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -3197,6 +3229,15 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/uuid": {

--- a/sample.env
+++ b/sample.env
@@ -29,6 +29,7 @@ MAHT_EMAIL= # get from admin
 MAHT_EMAIL_PASSWORD= # get from admin
 MCP_JSONRPC_Version=2.0
 MCP_JSONRPC_Protocol=2025-03-26
+MCP_PAGE_SIZE=100 # cursor and pagination for MCP specifically
 NANDA_REGISTRY_USER= # get from admin
 NANDA_REGISTRY_PASSWORD= # get from admin
 NANDA_REGISTRY_URL=https://nanda-registry.com/api/v1

--- a/server.js
+++ b/server.js
@@ -5,10 +5,7 @@ import { fileURLToPath } from 'url'
 /* server imports */
 import Koa from 'koa'
 import { koaBody } from 'koa-body'
-import koaConnect from 'koa-connect'
-import mount from 'koa-mount'
 import render from 'koa-ejs'
-import Router from 'koa-router'
 import session from 'koa-generic-session'
 import serve from 'koa-static'
 /* misc imports */
@@ -16,7 +13,7 @@ import chalk from 'chalk'
 /* local service imports */
 import SystemAvatar from './inc/js/mylife-factory.mjs'
 /** variables **/
-const version = '0.0.36'
+const version = '0.0.37'
 const app = new Koa()
 const port = process.env.PORT
 	?? '3000'
@@ -139,7 +136,7 @@ app.use(async (ctx, next) => {
 				httpOnly: false,
 				signed: true,
 				rolling: false,
-				renew: false,
+				renew: true,
 				store: MemoryStore,
 			},
 			app
@@ -181,6 +178,17 @@ app.listen(port, () => {	//	start the server
 	console.log(chalk.greenBright('server available'))
 	console.log(chalk.yellow(`listening on port ${port}`))
 })
+/** MCP session meta erasure **/
+const sessionCheckInterval = 10 * 60 * 1000 // every 10 minutes
+setInterval(async _=>{
+    for(const [sessionId, sessionIdKoa] of app.context.mcpSessionMeta){
+        const koaSess = await app.context.MemoryStore.get(`koa:sess:${sessionIdKoa}`)
+        if(!koaSess){
+            app.context.mcpSessionMeta.delete(sessionId)
+            console.log(`⏱️ Removed meta session for ${sessionId}`)
+        }
+    }
+}, sessionCheckInterval)
 /** server functions **/
 function checkForLiveAlerts(){
 	_Maht.alerts()

--- a/views/assets/js/globals.mjs
+++ b/views/assets/js/globals.mjs
@@ -362,16 +362,6 @@ class Datamanager {
         return response
     }
     /**
-     * Fetches the hosted members from the server.
-     * @private
-     * @returns {Promise<MemberList[]>} - The response Member List { id, name, } array.
-     */
-    async hostedMembers(){
-        const url = `select`
-        const responses = await this.#fetch(url)
-        return responses
-    }
-    /**
      * Deletes the item from the server.
      * @param {Guid} itemId - The collection item id
      * @returns {Object} - The item object: { item, message, success, }


### PR DESCRIPTION
closes #512 
closes #513 
closes #514 
closes #509 

* 485 version 0034 (#491) (#492)

* 20250404 @Mookse
- version change

* 20250411 @Mookse
- #490
- assign NANDA key

* 20250413 @Mookse
- MCP Exposure #490
- infancy, from another server

* Update inc/js/controllers/mcp-functions.mjs




* 20250414 @mookse
- quikc fixes to repo

---------




* Hotfix mcp catch (#505) (#506)

* 485 version 0034 (#491) (#492)

* 20250404 @Mookse
- version change

* 20250411 @Mookse
- #490
- assign NANDA key

* 20250413 @Mookse
- MCP Exposure #490
- infancy, from another server

* Update inc/js/controllers/mcp-functions.mjs




* 20250414 @mookse
- quikc fixes to repo

---------




* 20250421 @Mookse
- version

* 20250421 @Mookse
- mcp progress on chat

* 20250422 @Mookse
- MCP: getSharedMemories #504

* 20250424 @Mookse
- error control

* 20250424 @Mookse
- mcp-error catch
- remove docker artifacts

---------




* 20250512 @Mookse
- version update

* 20250515 @Mookse
- FIX: id was not correctly assigned

* 20250519 @Mookse
- BUG: MCP Inspector not validating SSE Stream #514

* 20250519 @Mookse
- MCP Batching #512 (wip, system avatar complete)
- Registration fix

* 20250520 @Mookse
- MCP Batching #512
- genericize progress token and cursor for arrays
- tested all 4 System Avatar functions

* 20250522 @Mookse
- MCP Batching #512
- member-avatar tools incorporated and tested
  - mcp_change_title
  - mcp_chat
  - mcp_get_summary
  - mcp_switch_bot

* 20250523 @Mookse
- MCP: add `mcp_get_memories`
- `bot-agent.mjs`: mcp_get_memories()
- `get_memories.json`
- NOTE: added directly to database

* 20250523 @Mookse
- FIX: protections for params and _meta

* 20250528 @Mookse
- minor cosmetics: add ES
- removed hostedMembers()

* 513 mcp transport streamable http (#519)

* Update routes.mjs

* 20250602 @Mookse
- MCP Transport: Streamable HTTP #513
- Tested sse & stramable functioning

* Update inc/js/mylife-datamanager.mjs




* Update inc/js/controllers/mcp-functions.mjs




---------




* 20250502 @Mookse
- remove auth for Bearer Token limitations temporarily

* 20250502 @Mookse
- return of notifications in mcp, though only initial stream, _GET_stream is not aintained across requests

* 20250503 @Mookse
- FIX: Progress Notifications
- FIX: Tool notifications

* 20250603 @Mookse
- MCP: on switch bot return tools changed

* 20250603 @Mookse
- MCP: Resource Templates

* 20250603 @Mookse
- MCP: Run poll (@20m/MYLIFE_SESSION_TIMEOUT_MS) to remove sessionMeta

* Update inc/js/mylife-datamanager.mjs




---------